### PR TITLE
feat: Add day (d) unit for time conversions (#7)

### DIFF
--- a/src/oxrse_unit_conv/units.py
+++ b/src/oxrse_unit_conv/units.py
@@ -8,6 +8,9 @@ minute = Unit(name='minute', abbr='min', si=second, to_si_fun=lambda n: n * 60)
 hour = Unit(name='hour', abbr='h', si=second, to_si_fun=lambda n: n * 3600)
 h = hour
 
+day = Unit(name='day', abbr='d', si=second, to_si_fun=lambda n: n * 86400)
+d = day
+
 # meter
 kilometer = Unit(name='kilometer', abbr="km", si=meter, to_si_fun=lambda n: n * 1000)
 km = kilometer

--- a/src/tests/test_unit_day.py
+++ b/src/tests/test_unit_day.py
@@ -1,0 +1,19 @@
+import unittest
+from oxrse_unit_conv.units import day, hour, second
+
+
+class TestDay(unittest.TestCase):
+    def test_SI(self):
+        self.assertTrue(day.si_unit.matches(second))
+
+    def test_basic_conversion(self):
+        self.assertEqual(day.to_si(1), 86400)
+        self.assertEqual(day.to_unit(10, day), 10)
+
+    def test_hour_conversion(self):
+        self.assertEqual(day.to_unit(1, hour), 24)
+        self.assertEqual(hour.to_unit(24, day), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Summary:**
This PR adds support for the day (d) unit to the time conversion utilities. The day unit is defined as 86,400 seconds and integrates with the existing unit conversion framework. Unit tests are included to verify conversions between days, hours, and seconds.

**Closes:** #7

**Details:**

- Adds `day` unit
- Provides alias `d`
- Adds `TestDay` class in `test_unit_day.py`
- Tests SI conversion and conversions to/from hours and seconds